### PR TITLE
Feat auto colonize

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -10,6 +10,7 @@ class Config:
         self.activateDefenderDiscordPing = None
         self.activateAutoEvasion = None
         self.activateAutoExpedition = None
+        self.activateAutoColonization = None
         self.activatePickingOfficers = None
         self.robotRatio = None
         self.robotStartingLevel = None
@@ -58,6 +59,8 @@ class Config:
                         self.activateAutoEvasion = value == "True"
                     elif key == "activateAutoExpedition":
                         self.activateAutoExpedition = value == "True"
+                    elif key == "activateAutoColonization":
+                        self.activateAutoColonization = value == "True"
                     elif key == "activatePickingOfficers":
                         self.activatePickingOfficers = value == "True"
                     elif key == "robotRatio":

--- a/Planet.py
+++ b/Planet.py
@@ -3,6 +3,7 @@ import time
 from bs4 import BeautifulSoup
 from Building import Building
 from Codes import Codes
+from Fleet import Fleet
 from Request import Request
 from tasks.BuildingTask import BuildingTask
 from UtilitiesFunctions import log
@@ -33,6 +34,7 @@ class Planet:
         self.sizeMax = None
         self.ships = {}
         self.customBuildOrder = None
+        self.lastKnownSystem = []
 
     def buildingById(self, id):
         for b in self.batiments:
@@ -282,12 +284,30 @@ class Planet:
             fleetroom = int(scriptRessources.split(':"')[1].split('"')[0])
             consumption = int(scriptRessources.split(':"')[2].split('"')[0])
             fleetroom -= consumption
-            thirdPayload["deuterium"] = min(ressources[2], fleetroom)
-            fleetroom -= thirdPayload["deuterium"]
-            thirdPayload["crystal"] = min(ressources[1], fleetroom)
-            fleetroom -= thirdPayload["crystal"]
-            thirdPayload["metal"] = min(ressources[0], fleetroom)
-            fleetroom -= thirdPayload["metal"]
+            if missionType == Fleet.colonizeCode:
+                thirdPayload["metal"] = min(ressources[0], fleetroom/2)
+                fleetroom -= thirdPayload["metal"]
+                thirdPayload["crystal"] = min(ressources[1], fleetroom*2/3)
+                fleetroom -= thirdPayload["crystal"]
+                thirdPayload["deuterium"] = min(ressources[2], fleetroom)
+                fleetroom -= thirdPayload["deuterium"]
+                if fleetroom >= 0:
+                    fleetroom += thirdPayload["metal"]
+                    thirdPayload["metal"] = min(ressources[0], fleetroom)
+                    fleetroom -= thirdPayload["metal"]
+                    fleetroom += thirdPayload["crystal"]
+                    thirdPayload["crystal"] = min(ressources[1], fleetroom)
+                    fleetroom -= thirdPayload["crystal"]
+                    fleetroom += thirdPayload["deuterium"]
+                    thirdPayload["deuterium"] = min(ressources[2], fleetroom)
+                    fleetroom -= thirdPayload["deuterium"]
+            else:
+                thirdPayload["deuterium"] = min(ressources[2], fleetroom)
+                fleetroom -= thirdPayload["deuterium"]
+                thirdPayload["crystal"] = min(ressources[1], fleetroom)
+                fleetroom -= thirdPayload["crystal"]
+                thirdPayload["metal"] = min(ressources[0], fleetroom)
+                fleetroom -= thirdPayload["metal"]
             thirdPayload["mission"  ] = missionType
             thirdPayload["staytime" ] = staytime
             thirdPayload["token"    ]  = token
@@ -332,7 +352,26 @@ class Planet:
                 planet = Planet(None, nameWithActivity, [galaxy, system, locationNumber, 1], None)
                 planets.append(planet)
                 #TODO add moon
+        for planet in self.player.planets:
+            if planet.pos[0] == galaxy and planet.pos[1] == system:
+                planet.lastKnownSystem = planets
         return planets
+
+    def scanOwnSystem(self):
+        return self.scanSystem(self.pos[0], self.pos[1])
+
+    def getColonizationTarget(self, useLastKnownSystem=False):
+        planetsList = self.lastKnownSystem
+        if not useLastKnownSystem:
+            planetsList = self.scanOwnSystem()
+        planetsDict = {}
+        for planet in planetsList:
+            if not planet.isMoon:
+                planetsDict[planet.pos[2]] = planet
+        for location in self.player.getColonizableLocations():
+            if planetsDict.get(location, None) is None: # No planet in this location
+                return location
+        return None
 
     def getPosAsString(self):
         return str(self.pos[0]) + ":" + str(self.pos[1]) + ":" + str(self.pos[2]) + ":" + str(self.pos[3])

--- a/Planet.py
+++ b/Planet.py
@@ -311,5 +311,28 @@ class Planet:
         buildShipReq = Request(self.player.ia.buildShipPage + "&cp=" + self.id, payload)
         self.player.ia.execRequest(buildShipReq)
 
+    def scanSystem(self, galaxy, system): #TODO add check for not enough deut
+        payload = {}
+        payload["galaxy"] = galaxy
+        payload["system"] = system
+        scanSystemRequest = Request(self.player.ia.galaxyPage + "&cp=" + self.id, payload)
+        self.player.ia.execRequest(scanSystemRequest)
+        soup = BeautifulSoup(scanSystemRequest.content, "html.parser")
+        #parse all available locations
+        divContent = soup.find("div", id="content")
+        systemTable = divContent.find("table", recursive=False)
+        locationList = systemTable.find_all("tr")[2:-5] #the first 2 and last 5 are headers
+        planets = []
+        locationNumber = 0
+        for location in locationList:
+            locationNumber += 1
+            tdList = location.find_all("td")
+            if tdList[0].a is None: # if there is a planet in this location
+                nameWithActivity = tdList[2].text #TODO remove activity from the name
+                planet = Planet(None, nameWithActivity, [galaxy, system, locationNumber, 1], None)
+                planets.append(planet)
+                #TODO add moon
+        return planets
+
     def getPosAsString(self):
         return str(self.pos[0]) + ":" + str(self.pos[1]) + ":" + str(self.pos[2]) + ":" + str(self.pos[3])

--- a/Player.py
+++ b/Player.py
@@ -213,6 +213,36 @@ class Player:
         soup = BeautifulSoup(checkAchievementRequest.content, "html.parser")
         return soup.find(class_="kategorie") is None
 
+    def getMaximumNumberOfPlanets(self):
+        astro = self.researchs.get(124, None)
+        if astro is None:
+            return 1
+        return (astro.level + 3) // 2
+
+    def getActualNumberOfPlanets(self):
+        number = 0
+        for planet in self.planets:
+            if not planet.isMoon:
+                number += 1
+        return number
+
+    def getColonizableLocations(self):
+        # Returns the colonizable locations in the 'best' order
+        astro = self.researchs.get(124, None)
+        if astro is None:
+            return []
+        else:
+            if astro.level >= 8:
+                return [8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]
+            elif astro.level >= 4:
+                return [8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14]
+            elif astro.level >= 2:
+                return [8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13]
+            elif astro.level >= 1:
+                return [8, 7, 9, 6, 10, 5, 11, 4, 12]
+            else:
+                return []
+
     def getMaximumNumberOfExpeditions(self):
         astro = self.researchs.get(124, None)
         if astro is None:

--- a/defaultConfig.txt
+++ b/defaultConfig.txt
@@ -11,6 +11,7 @@ activateAutoFleetScan=True
 activateDefenderDiscordPing=False
 activateAutoEvasion=False
 activateAutoExpedition=False
+activateAutoColonization=False
 activatePickingOfficers=False
 
 ## AutoBuild Settings

--- a/risistar.py
+++ b/risistar.py
@@ -45,6 +45,7 @@ class IA:
     battleSimulatorPage = "https://" + domain + "/game.php?page=battleSimulator&mode=send"
     battleRapportPage   = "https://" + domain + "/game.php?page=raport&raport="
     achievementsPage    = "https://" + domain + "/game.php?page=achievements"
+    galaxyPage          = "https://" + domain + "/game.php?page=galaxy"
 
     planetNameParser = re.compile(r'>(.*) \[(.*)\]')
     buildingNameParser = re.compile(r'\A([^\(]+)(?:\(.* (\d*))?')

--- a/risistar.py
+++ b/risistar.py
@@ -12,6 +12,7 @@ from Player import Player
 from Request import Request
 from tasks.Task import Task
 from tasks.CheckAchievementsTask import CheckAchievementsTask
+from tasks.ColonizeTask import ColonizeTask
 from tasks.PickOfficerTask import PickOfficerTask
 from tasks.PlanningTask import PlanningTask
 from tasks.ScanFleetsTask import ScanFleetsTask
@@ -82,6 +83,8 @@ class IA:
             self.addTask(ScanFleetsTask(time.time(), self.player, 0))
         if self.config.activatePickingOfficers:
             self.addTask(PickOfficerTask(time.time(), self.player))
+        if self.config.activateAutoColonization:
+            self.addTask(ColonizeTask(time.time(), self.player))
 
     def loadCustomBuildOrders(self):
         buildOrderDirectory = os.path.join(os.path.dirname(os.path.abspath(__file__)), self.config.customBuildOrdersDirectoryName)

--- a/tasks/ColonizeTask.py
+++ b/tasks/ColonizeTask.py
@@ -1,0 +1,51 @@
+import time
+from Fleet import Fleet
+from tasks.Task import Task
+from UtilitiesFunctions import log
+
+class ColonizeTask(Task):
+    def __init__(self, t, player):
+        self.t = t
+        self.player = player
+        self.prio = Task.lowPrio
+
+    def execute(self):
+        log(None, "Checking if colonization is possible")
+        if self.player.getMaximumNumberOfPlanets() > self.player.getActualNumberOfPlanets():
+            # This assures that tech is enough
+            # We just need to get a planet with a colonization ship or a shipyard 4
+            self.player.scanOwnShips()
+            scannedSystem = [] # We don't scan a scanned system
+            stop = False
+            for planet in self.player.planets:
+                if not stop and planet.ships.get(208, 0) >= 1:
+                    if [planet.pos[0], planet.pos[1]] in scannedSystem:
+                        location = planet.getColonizationTarget(useLastKnownSystem=True)
+                    else:
+                        location = planet.getColonizationTarget()
+                        scannedSystem.append([planet.pos[0], planet.pos[1]])
+                    if location is not None:
+                        stop = True
+                        destination = [planet.pos[0], planet.pos[1], location, 1]
+                        planet.sendFleet(destination, Fleet.colonizeCode, {208:1}, [0, 0, 0], allRessources=True)
+            if not stop: #ie no ship to send to colonize
+                log(None, "No colonization launched, trying to build a colony ship")
+                for planet in self.player.planets:
+                    canBuild = planet.buildingLevelById(21) >= 4 and planet.metal >= 10000 and planet.crystal >= 20000 and planet.deut >= 11000
+                    if not stop and planet.ships.get(208, 0) == 0 and canBuild:
+                        if [planet.pos[0], planet.pos[1]] in scannedSystem:
+                            location = planet.getColonizationTarget(useLastKnownSystem=True)
+                        else:
+                            location = planet.getColonizationTarget()
+                            scannedSystem.append([planet.pos[0], planet.pos[1]])
+                        spacePort = planet.buildingById(21)
+                        if location is not None:
+                            stop = True
+                            planet.buildShips({208:1})
+                            log(planet, "Started construction of colony ship")
+                            timeToWait = 30000/14/(1 + planet.buildingLevelById(21))/(2**planet.buildingLevelById(15)) + 5
+                            # The 14 is 2 * universe speed, the + 5 is just a security, could be 1
+                            newTask = ColonizeTask(time.time() + timeToWait, self.player)
+                            self.player.ia.addTask(newTask)
+            if not stop:
+                log(None, "Can't build any colony ships in a system with a colonizable planet")


### PR DESCRIPTION
At the start, a new task is added.
That tasks goes through all planets looking for a colony ship. If there is one and there is a colonizable planet in the same system then it will send it to colonize.
If there is no ship, it will attempt to build one on a planet where the construction is possible and which has a colonizable planet in the same system. It will add a new ColonizeTask scheduled for a little bit after the end of construction (warning: existing ships construction may delay the initial colony ship construction so the player may end up with several colony ships. To fix in a next PR) 

The resources sent with the colony ship are : 1/2 metal, 1/3 crystal, 1/6 deut. If there is still room (for example if the launching planet has 0 crystal), it will fill the remaining space with metal first, then crystal and finally deut.

All systems are scanned only once. That means that even if the player has 5 planets in the same system, it will scanned only once (to reduce the number of requests as usual)