### PR TITLE
Added watchdog

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -26,6 +26,10 @@ class Config:
         self.launchExpeditionSeparately = None
         self.officersPickingOrderFile = None
         self.researchPlanetId = None
+        self.watchdogDelay = None
+        self.watchdogExceptionDelay = None
+        self.watchdogEarlyDelay = None
+        self.watchdogWakeDuration = None
 
     def load():
         config = Config()
@@ -91,6 +95,14 @@ class Config:
                         self.launchExpeditionSeparately = value == "True"
                     elif key == "researchPlanetId":
                         self.researchPlanetId = int(value)
+                    elif key == "watchdogDelay":
+                        self.watchdogDelay = int(value)
+                    elif key == "watchdogExceptionDelay":
+                        self.watchdogExceptionDelay = int(value)
+                    elif key == "watchdogEarlyDelay":
+                        self.watchdogEarlyDelay = int(value)
+                    elif key == "watchdogWakeDuration":
+                        self.watchdogWakeDuration = int(value)
                 l = file.readline()
 
     def getError(self):
@@ -114,4 +126,14 @@ class Config:
             return "Defender ping is activated but the user id to ping isn't configurated !"
         if self.activatePickingOfficers and self.officersPickingOrderFile is None:
             return "Officer picking is activated but the order isn't configurated !"
+        if self.watchdogDelay is None:
+            return "watchdogDelay isn't defined"
+        if self.watchdogDelay <= 0:
+            return "watchdogDelay should be strictly positive (for example 1800 ie 30 minutes)"
+        if self.watchdogExceptionDelay is None:
+            return "watchdogExceptionDelay isn't defined (in doubt, put it at 0)"
+        if self.watchdogEarlyDelay is None:
+            return "watchdogEarlyDelay isn't defined (in doubt, put it at 0)"
+        if self.watchdogWakeDuration is None:
+            return "watchdogWakeDuration isn't defined (in doubt, put it at 5)"
         return None

--- a/defaultConfig.txt
+++ b/defaultConfig.txt
@@ -52,3 +52,16 @@ launchExpeditionSeparately=True
 officersPickingOrderFile=officersPickingOrder.txt
 
 researchPlanetId=0
+
+## Watchdog
+# The default delay in seconds between each reinitialization of the AI
+watchdogDelay=1800
+# If an exception is raised, the watchdog will wake sooner
+# This indicates the amount in seconds to subtract from the remaining time until the watchdog wake up
+watchdogExceptionDelay=60
+# After executing a task in the watchdogEarlyDelay seconds before the watchdog wakes up,
+# If there is no mid to high priority task scheduled in the next watchdogWakeDuration seconds,
+# Then wake the watchdog early
+watchdogEarlyDelay=60
+# watchdogWakeDuration should be a bit more than the time to initialize the AI
+watchdogWakeDuration=5


### PR DESCRIPTION
Added a watchdog (works a bit like a super high priority task).
When executing ia.run(), the watchdog may wake up. It will then reinitialize the ia and go back to sleep.
The watchdog sleeps for  config.watchdogDelay seconds. Each time an exception from a task is raised, it will wake config.watchdogExceptionDelay sooner (cumulates).
Additionally, when checking if the watchdog should wake up, if it should wake up in the next config.watchdogEarlyDelay seconds and if no high or middle priority task is scheduled in the next config.watchdogWakeDuration seconds, then it wakes up early.
This is so the watchdog can wake up when no important task is scheduled and to reduce the chance of it waking up right before an important task is scheduled (for example just before scanning fleets)

TODO in next PR : Fix the "spotting time" from fleets being reinitialized (if a fleet is spotted before the wake up, it will be forgotten at the wake up, resulting in a spotting time smaller than what it should be)