### PR TITLE
Fix diverse bug

### DIFF
--- a/Fleet.py
+++ b/Fleet.py
@@ -28,6 +28,9 @@ class Fleet:
     def isAttack(self):
         return self.type == "attack"
 
+    def isColony(self):
+        return self.type == "colony" or self.type == "owncolony"
+
     def isDestroy(self):
         return self.type == "destroy"
 

--- a/Player.py
+++ b/Player.py
@@ -75,6 +75,10 @@ class Player:
                     pl.scan()
 
     def getFleets(self):
+        researchEspionage = self.researchs.get(106, None)
+        researchEspionageLevel = 0
+        if researchEspionage is not None:
+            researchEspionageLevel = researchEspionage.level
         fleets = {}
         overviewRequest = Request(self.ia.overviewPage, {})
         self.ia.execRequest(overviewRequest)
@@ -94,7 +98,7 @@ class Player:
             ships = {}
             for fleetSpan in fleetsSpans:
                 shipsA = fleetSpan.find("a", class_="tooltip")
-                if shipsA is not None:
+                if shipsA is not None and researchEspionageLevel >= 8:
                     shipsSoup = BeautifulSoup(shipsA.attrs["data-tooltip-content"], "html.parser")
                     for tr in shipsSoup.findAll("tr"):
                         tds = tr.findAll("td")

--- a/customBuildOrdersPairingFile.txt
+++ b/customBuildOrdersPairingFile.txt
@@ -6,3 +6,4 @@
 #No "=" is allowed in the custom build order name
 Main Planet=Mother
 Colony=Colony
+Colonie=Colony

--- a/tasks/ColonizeTask.py
+++ b/tasks/ColonizeTask.py
@@ -11,7 +11,11 @@ class ColonizeTask(Task):
 
     def execute(self):
         log(None, "Checking if colonization is possible")
-        if self.player.getMaximumNumberOfPlanets() > self.player.getActualNumberOfPlanets():
+        isAlreadyColonizing = False
+        for fleet in self.player.fleets.values():
+            if not isAlreadyColonizing and fleet.isColony():
+                isAlreadyColonizing = True
+        if not isAlreadyColonizing and self.player.getMaximumNumberOfPlanets() > self.player.getActualNumberOfPlanets():
             # This assures that tech is enough
             # We just need to get a planet with a colonization ship or a shipyard 4
             self.player.scanOwnShips()
@@ -27,6 +31,7 @@ class ColonizeTask(Task):
                     if location is not None:
                         stop = True
                         destination = [planet.pos[0], planet.pos[1], location, 1]
+                        log(None, "Colonizing " + str(destination))
                         planet.sendFleet(destination, Fleet.colonizeCode, {208:1}, [0, 0, 0], allRessources=True)
             if not stop: #ie no ship to send to colonize
                 log(None, "No colonization launched, trying to build a colony ship")


### PR DESCRIPTION
When espionage level is < 8, don't scan fleet composition (might want to scan for allied fleets, but there is no need for it right now). Couldn't be tested (runs well with >= 8 though)
Add "Colonie" as a synonym for custom build order pairing (planets named "Colonie" will use the custom build order "Colony").
If there is a colony fleet underway, don't attempt to colonize. This mitigates the problem of multiple colony ships being built. However, it can still happen if the watchdog wakes up while a colony ship is being built (as ships being built aren't scanned).