### PR TITLE
Refacto of pick order

### DIFF
--- a/BuildOrder.py
+++ b/BuildOrder.py
@@ -1,40 +1,10 @@
-class BuildOrder:
-    def __init__(self, name, buildings=[], filePath=None):
+from PickOrder import PickOrder
+
+class BuildOrder(PickOrder):
+    def __init__(self, name, list=[], filePath=None):
+        super().__init__(list, filePath)
         self.name = name
-        self.buildings = buildings
-        self.useDefaultBuildPlanWhenEmpty = True
-        if filePath is not None:
-            self.loadFromFile(filePath)
 
     def nextBuilding(self, planet):
-        buildingsAtThisStep = {}
-        for stepNumber in range(len(self.buildings)):
-            buildingId = self.buildings[stepNumber] #the buildingId to be built according to this step
-            levelToBuild = buildingsAtThisStep.get(buildingId, 0) + 1  #the level it should be after building
-            buildingsAtThisStep[buildingId] = levelToBuild
-            currentLevel = planet.buildingLevelById(buildingId)
-            if levelToBuild > currentLevel:
-                return buildingId
-        return None
-
-    def loadFromFile(self, filePath):
-        self.buildings = []
-        with open(filePath) as file:
-            l = file.readline()
-            startedBuildingsList = False
-            while l != "":
-                l = l.replace("\n", "")
-                if len(l) and l[0] != "#":
-                    if not startedBuildingsList:
-                        if l == "Buildings:":
-                            startedBuildingsList = True
-                        else:
-                            s = l.split("=")
-                            key = s[0].replace(" ", "")
-                            value = s[1]
-                            if key == "useDefaultBuildPlanWhenEmpty":
-                                self.useDefaultBuildPlanWhenEmpty = value == "True"
-                            #TODO add more configurations at the beginning of the build order
-                    else:
-                        self.buildings.append(int(l))
-                l = file.readline()
+        idToItem = lambda buildingId: planet.buildingById(buildingId)
+        return self.nextItem(idToItem)

--- a/Config.py
+++ b/Config.py
@@ -6,6 +6,7 @@ class Config:
         self.userAgent = None
         self.activateAutoBuild = None
         self.activateCustomBuildOrders = None
+        self.activateAutoResearch = None
         self.activateAutoFleetScan = None
         self.activateDefenderDiscordPing = None
         self.activateAutoEvasion = None
@@ -16,6 +17,7 @@ class Config:
         self.robotStartingLevel = None
         self.customBuildOrdersDirectoryName = None
         self.customBuildOrdersPairingFile = None
+        self.techsPickingOrderFile = None
         self.minimumTimeBetweenScans = None
         self.randomAdditionnalTimeBetweenScans = None
         self.webhookUrl = None
@@ -25,7 +27,6 @@ class Config:
         self.minimumSpottingTime = None
         self.launchExpeditionSeparately = None
         self.officersPickingOrderFile = None
-        self.researchPlanetId = None
         self.watchdogDelay = None
         self.watchdogExceptionDelay = None
         self.watchdogEarlyDelay = None
@@ -55,6 +56,8 @@ class Config:
                         self.activateAutoBuild = value == "True"
                     elif key == "activateCustomBuildOrders":
                         self.activateCustomBuildOrders = value == "True"
+                    elif key == "activateAutoResearch":
+                        self.activateAutoResearch = value == "True"
                     elif key == "activateAutoFleetScan":
                         self.activateAutoFleetScan = value == "True"
                     elif key == "activateDefenderDiscordPing":
@@ -75,6 +78,8 @@ class Config:
                         self.customBuildOrdersDirectoryName = value
                     elif key == "customBuildOrdersPairingFile":
                         self.customBuildOrdersPairingFile = value
+                    elif key == "techsPickingOrderFile":
+                        self.techsPickingOrderFile = value
                     elif key == "minimumTimeBetweenScans":
                         self.minimumTimeBetweenScans = int(value)
                     elif key == "randomAdditionnalTimeBetweenScans":
@@ -93,8 +98,6 @@ class Config:
                         self.officersPickingOrderFile = value
                     elif key == "launchExpeditionSeparately":
                         self.launchExpeditionSeparately = value == "True"
-                    elif key == "researchPlanetId":
-                        self.researchPlanetId = int(value)
                     elif key == "watchdogDelay":
                         self.watchdogDelay = int(value)
                     elif key == "watchdogExceptionDelay":

--- a/OfficersPickingOrder.py
+++ b/OfficersPickingOrder.py
@@ -1,30 +1,7 @@
-class OfficersPickingOrder:
-    def __init__(self, officers=[], filePath=None):
-        self.officers = officers
-        if filePath is not None:
-            self.loadFromFile(filePath)
+from PickOrder import PickOrder
+
+class OfficersPickingOrder(PickOrder):
 
     def nextOfficer(self, currentOfficers):
-        officersAtThisStep = {}
-        for stepNumber in range(len(self.officers)):
-            officerId = self.officers[stepNumber] #the officerId to be built according to this step
-            levelToGet = officersAtThisStep.get(officerId, 0) + 1  #the level it should be after getting it
-            officersAtThisStep[officerId] = levelToGet
-            currentOfficer = currentOfficers.get(officerId, None)
-            if currentOfficer is not None and levelToGet > currentOfficer.level:
-                return currentOfficer
-        return None
-
-    def loadFromFile(self, filePath):
-        self.officers = []
-        with open(filePath) as file:
-            l = file.readline()
-            while l != "":
-                l = l.replace("\n", "")
-                if len(l) and l[0] != "#":
-                    if not ":" in l:
-                        l += ":1"
-                    id, times = l.split(":")
-                    for i in range(int(times)):
-                        self.officers.append(int(id))
-                l = file.readline()
+        idToItem = lambda officerId: currentOfficers.get(officerId, None)
+        return self.nextItem(idToItem)

--- a/PickOrder.py
+++ b/PickOrder.py
@@ -1,0 +1,46 @@
+from UtilitiesFunctions import is_number
+
+class PickOrder:
+    def __init__(self, list=[], filePath=None):
+        self.list = list
+        self.options = {}
+        if filePath is not None:
+            self.loadFromFile(filePath)
+
+    def loadFromFile(self, filePath):
+        self.list = []
+        self.options = {}
+        with open(filePath) as file:
+            l = file.readline()
+            startedOrderList = False
+            while l != "":
+                l = l.replace("\n", "")
+                if len(l) and l[0] != "#":
+                    if l[0].isdigit():
+                        if not ":" in l:
+                            l += ":1"
+                        id, times = l.split(":")
+                        for i in range(int(times)):
+                            self.list.append(int(id))
+                    else:
+                        s = l.split("=")
+                        key = s[0].replace(" ", "")
+                        value = s[1]
+                        if value == "True" or "False":
+                            self.options[key] = value == "True"
+                        elif is_number(value):
+                            self.options[key] = float(value)
+                        else:
+                            self.options[key] = value
+                l = file.readline()
+
+    def nextItem(self, idToItem):
+        itemsAtThisStep = {}
+        for stepNumber in range(len(self.list)):
+            itemId = self.list[stepNumber] #the itemId to be selected according to this step
+            levelToGet = itemsAtThisStep.get(itemId, 0) + 1  #the level it should be after getting it
+            itemsAtThisStep[itemId] = levelToGet
+            currentItem = idToItem(itemId)
+            if currentItem is not None and levelToGet > currentItem.level:
+                return currentItem
+        return None

--- a/Planet.py
+++ b/Planet.py
@@ -77,13 +77,15 @@ class Planet:
         config = self.player.ia.config #to make lines smaller
         buildingId = None
         if config.activateCustomBuildOrders and self.customBuildOrder is not None:
-            buildingId = self.customBuildOrder.nextBuilding(self) #id of the building to build
-            if buildingId is None:
-                if self.customBuildOrder.useDefaultBuildPlanWhenEmpty:
+            building = self.customBuildOrder.nextBuilding(self) # the building to build
+            if building is None:
+                if self.customBuildOrder.options.get("useDefaultBuildPlanWhenEmpty", False):
                     buildingId = self.defaultPlanBuildingWithoutHangars()
                 else:
                     log(self, "No more building planned by the custom build order !")
                     return None
+            else:
+                buildingId = building.id
         else:
             buildingId = self.defaultPlanBuildingWithoutHangars()
         buildingId = self.planHangarsInstead(buildingId)

--- a/Planet.py
+++ b/Planet.py
@@ -29,6 +29,7 @@ class Planet:
         self.energyStorage = None
         self.lastExtracedInfosDate = None
         self.upgradingEnd = 0 #when the last upgrade will finish. Either 0 or time.time() + rest
+        self.upgradingBuildingsId = [] # List of (id, end) with id of the buildings being upgraded and end of the construction
         self.isMoon = "(Lune)" in name
         self.sizeUsed = None
         self.sizeMax = None
@@ -73,6 +74,18 @@ class Planet:
             return True
         return False
 
+    def getTimeToWaitForResources(self, resourcesWanted):
+        resources = [x for x in resourcesWanted] # copy to not change original list
+        resources[0] = (resources[0] - self.metal) / self.metalProduction
+        resources[1] = (resources[1] - self.crystal) /  self.crystalProduction
+        if self.deutProduction == 0:
+            resources[2] = 0 if (self.deut - resources[2]) >= 0 else math.inf
+        else:
+            resources[2] = (resources[2] - self.deut) /  self.deutProduction
+        resources.append(0) #to ensure that the wait time is at least 0
+        timeToWait = max(resources)
+        return timeToWait
+
     def planBuilding(self):
         config = self.player.ia.config #to make lines smaller
         buildingId = None
@@ -91,15 +104,7 @@ class Planet:
         buildingId = self.planHangarsInstead(buildingId)
         building = self.buildingById(buildingId)
         #now we need to know how much to wait
-        t = [x for x in building.upgradeCost] #the ressources needed
-        t[0] = (t[0] - self.metal) / self.metalProduction
-        t[1] = (t[1] - self.crystal) /  self.crystalProduction
-        if self.deutProduction == 0:
-            t[2] = 0 if (self.deut - t[2]) >= 0 else math.inf
-        else:
-            t[2] = (t[2] - self.deut) /  self.deutProduction
-        t.append(0) #to ensure that the task execute time is at least time.time()
-        timeToWait = max(t)
+        timeToWait = self.getTimeToWaitForResources(building.upgradeCost)
         task = BuildingTask(time.time() + timeToWait, building)
         self.player.ia.addTask(task)
         return task
@@ -153,9 +158,13 @@ class Planet:
         bats = soup.find(id="content").find_all("div", recursive=False)
         self.batiments = []
         self.upgradingEnd = 0
+        self.upgradingBuildingsId = []
         for b in bats:
             if b.attrs.get("id") == "buildlist": #if it's a building currently building
-                self.upgradingEnd = float(b.find(class_="timer").attrs["data-time"]) #at the end of the loop, it will be the end of the last building
+                endTime = float(b.find(class_="timer").attrs["data-time"])
+                self.upgradingEnd = endTime #at the end of the loop, it will be the end of the last building
+                buildingId = int(b.find("input", attrs={"name": "building"}).attrs["value"])
+                self.upgradingBuildingsId.append((buildingId, endTime))
             else:
                 nameAndLevelText = b.find("a").text
                 nameAndLevel = self.player.ia.buildingNameParser.findall(nameAndLevelText)

--- a/Player.py
+++ b/Player.py
@@ -6,6 +6,7 @@ from Codes import Codes
 from Fleet import Fleet
 from Officer import Officer
 from OfficersPickingOrder import OfficersPickingOrder
+from TechsPickingOrder import TechsPickingOrder
 from Planet import Planet
 from Request import Request
 from Technology import Technology
@@ -23,11 +24,14 @@ class Player:
         self.fleets = {} #friendly, own and hostile. Dictionnary id=>fleet
         self.officers = {}
         self.techs = {}
-        self.researchingEnd = None
+        self.researchEnd = 0
         self.ia = ia
         self.officersPickingOrder = None
+        self.techsPickingOrder = None
         if ia.config.activatePickingOfficers:
             self.officersPickingOrder = OfficersPickingOrder(filePath=ia.config.officersPickingOrderFile)
+        if ia.config.activateAutoResearch:
+            self.techsPickingOrder = TechsPickingOrder(filePath=ia.config.techsPickingOrderFile)
 
     def connexion(self):
         payload = {
@@ -144,8 +148,12 @@ class Player:
         return res
 
     def scanTechs(self):
-        techRequest = Request(self.ia.researchPage + "&cp=" + str(self.ia.config.researchPlanetId), {})
+        level, planet = self.getPlanetsWithBuildingOrderedByLevel(31)[0]
+        techRequest = Request(self.ia.researchPage + "&cp=" + str(planet.id), {})
         self.ia.execRequest(techRequest)
+        self.scanTechsUsingRequest(techRequest)
+
+    def scanTechsUsingRequest(self, techRequest):
         content = techRequest.content
         content = content.replace(")</a></div>", ")</div>") #the site is broken here
         content = content.replace("></a></div>", "></div>")
@@ -153,10 +161,10 @@ class Player:
         #parse all available techs
         techs = soup.find(id="content").find_all("div", recursive=False)
         self.techs = {}
-        self.researchingEnd = 0
+        self.researchEnd = 0
         for r in techs:
             if r.attrs.get("id") == "buildlist": #if it's a techs being currently researched
-                self.researchingEnd = float(r.find(class_="timer").attrs["data-time"]) #at the end of the loop, it will be the end of the last tech
+                self.researchEnd = float(r.find(class_="timer").attrs["data-time"]) #at the end of the loop, it will be the end of the last tech
             else:
                 nameElement = r.find("a")
                 name = nameElement.text
@@ -212,11 +220,60 @@ class Player:
     def chooseOfficerToPick(self): #doesn't check if enough DM
         return self.officersPickingOrder.nextOfficer(self.officers)
 
+    def chooseTechToPick(self):
+        log(None, "Planning tech to research")
+        techId = None
+        if self.techsPickingOrder is not None:
+            tech = self.techsPickingOrder.nextTech(self.techs) # the tech to research
+            if tech is None:
+                if self.techsPickingOrder.options.get("useDefaultTechPlanWhenEmpty", False):
+                    tech = self.chooseTechToPickByDefault()
+                else:
+                    log(self, "No more techs planned by the technology picking order !")
+                    return None
+        else:
+            tech = self.chooseTechToPickByDefault()
+        if tech is not None:
+            # Now we need to find a suitable planet to research it
+            level, planet = self.getPlanetsWithBuildingOrderedByLevel(31)[0] # The planet with highest lab
+            return tech, planet
+
+    def chooseTechToPickByDefault(self):
+        """The logic is the following : astrophysic when astro.cost < 4 * computer.cost, else computer"""
+        tech = None
+        astro = self.techs.get(124, None)
+        astroCost = 0
+        if astro is not None:
+            astroCost = astro.getTotalUpgradeCostWeighted()
+        computer = self.techs.get(108, None)
+        computerCost = 0
+        if computer is not None:
+            computerCost = computer.getTotalUpgradeCostWeighted()
+        if astroCost < 4 * computerCost:
+            if astro is not None:
+                return astro
+            else:
+                return Technology(Codes.idToStr[124], 124, self)
+        else:
+            if computer is not None:
+                return computer
+            else:
+                return Technology(Codes.idToStr[108], 108, self)
+
     def checkNewAchievement(self): #returns True if a new achievement was achieved
         checkAchievementRequest = Request(self.ia.achievementsPage, {})
         self.ia.execRequest(checkAchievementRequest)
         soup = BeautifulSoup(checkAchievementRequest.content, "html.parser")
         return soup.find(class_="kategorie") is None
+
+    def getPlanetsWithBuildingOrderedByLevel(self, buildingId, descendingOrder=True):
+        list = []
+        for planet in self.planets:
+            buildingLevel = planet.buildingLevelById(buildingId)
+            if buildingLevel > 0:
+                list.append((buildingLevel, planet))
+        list.sort(key=lambda x:x[0], reverse=descendingOrder)
+        return list
 
     def getMaximumNumberOfPlanets(self):
         astro = self.techs.get(124, None)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ You can add more custom build orders in the folder (which name is defined in the
 Do not use an "=" in the name of a custom build order file (everything else *should* be ok).
 The AI will give each planet a custom build order according to the planet name.
 To specify which planet name should add which custom build order, you can alter the `customBuildOrdersPairingFile.txt` (name of the file defined in the configuration).
-**DO NOT** add buildings before the needed buildings/researchs/officers for it are taken.
+**DO NOT** add buildings before the needed buildings/techs/officers for it are taken.
 
-In the future, we plan to add a check if the building is buildable (ie. if the buildings/researchs/officiers it needs are taken).
+In the future, we plan to add a check if the building is buildable (ie. if the buildings/techs/officiers it needs are taken).
 Additionally, we are thinking about adding a settings which will allow if the current building isn't buildable to build the next one instead.
 
 ### AutoFleetScan

--- a/Technology.py
+++ b/Technology.py
@@ -15,9 +15,16 @@ class Technology:
                 return False
         return True
 
-    def upgrade(self):
+    def upgrade(self, planetId):
         if self.id != None:
             payload = {'cmd': 'insert', 'tech': self.id}
-            reqB = Request(self.player.ia.techPage + "&cp=" + str(self.player.ia.config.techPlanetId), payload)
+            reqB = Request(self.player.ia.researchPage + "&cp=" + str(planetId), payload)
             self.player.ia.execRequest(reqB)
             return reqB
+
+    def getTotalUpgradeCostWeighted(self, weight=[3, 2, 1]):
+        """sum of upgradeCost[i]/weight[i]"""
+        sum = 0
+        for i in range(3):
+            sum += self.upgradeCost[i]/weight[i]
+        return sum

--- a/Technology.py
+++ b/Technology.py
@@ -1,6 +1,6 @@
 from Request import Request
 
-class Research:
+class Technology:
     def __init__(self, type, id, player, level=0):
         self.type = type
         self.level = level
@@ -18,6 +18,6 @@ class Research:
     def upgrade(self):
         if self.id != None:
             payload = {'cmd': 'insert', 'tech': self.id}
-            reqB = Request(self.player.ia.researchPage + "&cp=" + str(self.player.ia.config.researchPlanetId), payload)
+            reqB = Request(self.player.ia.techPage + "&cp=" + str(self.player.ia.config.techPlanetId), payload)
             self.player.ia.execRequest(reqB)
             return reqB

--- a/TechsPickingOrder.py
+++ b/TechsPickingOrder.py
@@ -1,0 +1,7 @@
+from PickOrder import PickOrder
+
+class TechsPickingOrder(PickOrder):
+
+    def nextTech(self, currentTechs):
+        idToItem = lambda techId: currentTechs.get(techId, None)
+        return self.nextItem(idToItem)

--- a/UtilitiesFunctions.py
+++ b/UtilitiesFunctions.py
@@ -5,3 +5,13 @@ def log(planet, str, isError=False):
         print(time.strftime("%H:%M:%S"), " [", planet.id, "] ", str, sep='')
     else:
         print(time.strftime("%H:%M:%S"), " [   ] ", str, sep='')
+
+def is_number(n):
+    is_number = True
+    try:
+        num = float(n)
+        # check for "nan" floats
+        is_number = num == num   # or use `math.isnan(num)`
+    except ValueError:
+        is_number = False
+    return is_number

--- a/buildOrders/Colony.txt
+++ b/buildOrders/Colony.txt
@@ -3,7 +3,6 @@
 useDefaultBuildPlanWhenEmpty=True
 
 #After all settings, the buildings list begins :
-Buildings:
 #Put the id of the building to build on each line
 1
 1

--- a/buildOrders/Mother.txt
+++ b/buildOrders/Mother.txt
@@ -7,7 +7,6 @@
 useDefaultBuildPlanWhenEmpty=True
 
 #After all settings, the buildings list begins :
-Buildings:
 #Put the id of the building to build on each line
 #1 metal mine
 #2 crystal mine
@@ -54,4 +53,3 @@ Buildings:
 4
 2
 1
-

--- a/defaultConfig.txt
+++ b/defaultConfig.txt
@@ -7,6 +7,7 @@ userAgent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:67.0) Gecko/20100101 Fire
 ## Features activation
 activateAutoBuild=True
 activateCustomBuildOrders=False
+activateAutoResearch=True
 activateAutoFleetScan=True
 activateDefenderDiscordPing=False
 activateAutoEvasion=False
@@ -31,6 +32,9 @@ customBuildOrdersPairingFile=customBuildOrdersPairingFile.txt
 minimumTimeBetweenScans=30
 randomAdditionnalTimeBetweenScans=10
 
+## Auto Tech settings
+techsPickingOrderFile=techsPickingOrder.txt
+
 ##Ennemy fleet discord ping
 webhookUrl=None
 idToPing=None
@@ -50,8 +54,6 @@ launchExpeditionSeparately=True
 
 ##Getting Officers settings
 officersPickingOrderFile=officersPickingOrder.txt
-
-researchPlanetId=0
 
 ## Watchdog
 # The default delay in seconds between each reinitialization of the AI

--- a/risistar.py
+++ b/risistar.py
@@ -16,6 +16,7 @@ from tasks.Task import Task
 from tasks.CheckAchievementsTask import CheckAchievementsTask
 from tasks.ColonizeTask import ColonizeTask
 from tasks.PickOfficerTask import PickOfficerTask
+from tasks.PickTechTask import PickTechTask
 from tasks.PlanningTask import PlanningTask
 from tasks.ScanFleetsTask import ScanFleetsTask
 from UtilitiesFunctions import log
@@ -95,6 +96,8 @@ class IA:
             for p in self.player.planets:
                 if not p.isMoon:
                     self.addTask(PlanningTask(time.time(), p))
+        if self.config.activateAutoResearch:
+            self.addTask(PickTechTask(time.time(), self.player))
         if self.config.activateAutoFleetScan:
             self.addTask(ScanFleetsTask(time.time(), self.player, 0))
         if self.config.activatePickingOfficers:
@@ -131,6 +134,13 @@ class IA:
 
     def addTask(self, t):
         heapq.heappush(self.tasks[t.prio], t)
+
+    def hasTaskOfType(self, type):
+        for prio in Task.descendingPrio:
+            for task in self.tasks[prio]:
+                if isinstance(task, type):
+                    return True
+        return False
 
     def checkWatchdog(self): # Returns True if the watchdog wakes
         timeUntilWatchdog = self.watchdog - time.time()

--- a/risistar.py
+++ b/risistar.py
@@ -6,6 +6,7 @@ import re
 import sys
 import threading
 import time
+import traceback
 from BuildOrder import BuildOrder
 from CombatReport import CombatReport
 from Config import Config
@@ -162,8 +163,10 @@ class IA:
                     taskToExecute = heapq.heappop(self.tasks[prio])
                     try:
                         taskToExecute.execute()
-                    except:
+                    except Exception:
                         log(None, "An exception occured while executing a " + taskToExecute.__class__.__name__)
+                        log(None, "Exception traceback :")
+                        traceback.print_exc()
                         self.watchdog -= self.config.watchdogExceptionDelay
                     taskExecuted = True
             # See if the watchdog wakes

--- a/risistar.py
+++ b/risistar.py
@@ -81,7 +81,7 @@ class IA:
         self.player = Player(self.pseudo, self.password, "Risistar", self)
         self.player.connexion()
         self.player.extractInfos(planets=True, darkMatter=True)
-        self.player.scanResearchs()
+        self.player.scanTechs()
         self.tasks = {}
         self.tasks[Task.lowPrio   ] = [] #building, technos ...
         self.tasks[Task.middlePrio] = [] #scanning fleets

--- a/risistar.py
+++ b/risistar.py
@@ -24,6 +24,7 @@ with open("secret.txt") as file:
     password = file.readline().replace("\n", "")  # en clair
 
 class IA:
+    _file = __file__
     config = Config.load()
     error = config.getError()
     if error is not None:
@@ -101,7 +102,7 @@ class IA:
             self.addTask(ColonizeTask(time.time(), self.player))
 
     def loadCustomBuildOrders(self):
-        buildOrderDirectory = os.path.join(os.path.dirname(os.path.abspath(__file__)), self.config.customBuildOrdersDirectoryName)
+        buildOrderDirectory = os.path.join(os.path.dirname(os.path.abspath(IA._file)), self.config.customBuildOrdersDirectoryName)
         if os.path.exists(buildOrderDirectory):
             buildOrderFiles = [f for f in os.listdir(buildOrderDirectory) if os.path.isfile(os.path.join(buildOrderDirectory, f))]
             for buildOrderFile in buildOrderFiles:

--- a/tasks/PickTechTask.py
+++ b/tasks/PickTechTask.py
@@ -1,0 +1,50 @@
+import time
+from Codes import Codes
+from tasks.Task import Task
+from tasks.ColonizeTask import ColonizeTask
+from UtilitiesFunctions import log
+
+class PickTechTask(Task):
+    def __init__(self, t, player):
+        self.t = t
+        self.player = player
+        self.prio = Task.lowPrio
+
+    def execute(self):
+        self.player.scanTechs()
+        if self.player.ia.config.activateAutoColonization:
+            # Eventually add a colonization task
+            isAlreadyColonizing = False
+            for fleet in self.player.fleets.values():
+                if not isAlreadyColonizing and fleet.isColony():
+                    isAlreadyColonizing = True
+            shouldAddTask = not isAlreadyColonizing
+            shouldAddTask = shouldAddTask and self.player.getActualNumberOfPlanets() < self.player.getMaximumNumberOfPlanets()
+            shouldAddTask = shouldAddTask and not self.player.ia.hasTaskOfType(ColonizeTask)
+            if shouldAddTask:
+                newTask = ColonizeTask(time.time(), self.player)
+                self.player.ia.addTask(newTask)
+        if self.player.researchEnd > 0: #If there is already a tech being researched
+            log(None, "Waiting for a research to finish in " + str(self.player.researchEnd - time.time()))
+            newTask = PickTechTask(self.player.researchEnd + 1, self.player)
+            self.player.ia.addTask(newTask)
+        else:
+            tech, planet = self.player.chooseTechToPick()
+            if tech is not None:
+                if tech.upgradable([planet.metal, planet.crystal, planet.deut]):
+                    req = tech.upgrade(planet.id)
+                    self.player.scanTechsUsingRequest(self.player.lastRequest)
+                    log(planet, "Researching %s in %s" % (tech.type, str(self.player.researchEnd - time.time())))
+                    newTask = PickTechTask(self.player.researchEnd + 1, self.player)
+                    self.player.ia.addTask(newTask)
+                else:
+                    #now we need to know how much to wait
+                    log(planet, "Waiting for resources for tech %s" % tech.type)
+                    timeToWait = planet.getTimeToWaitForResources(tech.upgradeCost)
+                    timeToStart = time.time() + timeToWait
+                    newTaskTime = timeToStart
+                    if len(planet.upgradingBuildingsId) and planet.upgradingBuildingsId[0][1] < timeToStart:
+                        # A building is planned before we can start the research
+                        newTaskTime = planet.upgradingBuildingsId[0][1]
+                    newTask = PickTechTask(newTaskTime, self.player)
+                    self.player.ia.addTask(newTask)

--- a/tasks/SendExpeditionTask.py
+++ b/tasks/SendExpeditionTask.py
@@ -27,8 +27,8 @@ class SendExpeditionTask(Task):
                     log(planet, "Launched an expedition!")
         if not stop: #ie no ship to send on any planet
             log(None, "No expedition launched, trying to build a small transporter")
-            combustionResearch = self.player.researchs.get(115, None)
-            if combustionResearch is not None and combustionResearch.level >= 2:
+            combustionTech = self.player.techs.get(115, None)
+            if combustionTech is not None and combustionTech.level >= 2:
                 for planet in self.player.planets:
                     if not stop and planet.metal >= 2000 and planet.crystal >= 2000 and planet.deut >= 10:
                         spacePort = planet.buildingById(21)

--- a/techsPickingOrder.txt
+++ b/techsPickingOrder.txt
@@ -1,0 +1,51 @@
+#This is a comment
+#Comments and empty lines are allowed
+
+#If all techs listed here are built, should the ai use it's own tech logic ?
+useDefaultTechPlanWhenEmpty=True
+
+#After all settings, the techs list begins :
+#Put the id of the tech to research on each line
+
+# First rush small cargo
+# Energy level 1
+113
+# Combustion level 2
+115:2
+
+#Then rush colony ships
+# Espionage level 3
+106:3
+# Impulsion propulsion level 3
+117:3
+# Astrophysic level 1
+124
+
+# Then take 2 level in computer to evade while colonizing and making expeditions
+# Computer to level 2
+108:2
+
+# Then take the techs for large cargo
+# Combustion from 2 to 6
+115:4
+
+# Then take the techs for small laser to be able to dump remaining crystal in case of an attack
+# Energy from 1 to 2
+113
+
+# Laser to level 3
+120:3
+
+# Then take 2 more levels in Astrophysic
+# Astrophysic from 1 to 3
+124:2
+
+# Then take 1 more level in computer to evade while colonizing and making expeditions
+# Computer from 2 to 3
+108
+
+# Finally unlock the resources production upgrade tech
+# Energy from 2 to 5
+113:3
+
+# Then we can fallback to the ai own logic (hopefully)


### PR DESCRIPTION
I've been working on the research. So I refactored the code for the pick order of officers and buildings so that it will be much clearer when I add the code for the pick order of research

EDIT : 
Auto research has been added.
Included is :
- renaming of "research" to "tech(nology)" in general
- a custom research picking order (rush SC, Astro, ...)
- a default research plan (if astro costs less than 4 times the cost of computer, take astro, else take computer)
- a compatibility with AutoColonize : when a research is being researched, check if a ColonizeTask should be added (as it happens when astro has just been researched. This way, no need to wait for the watchdog)
- removed the setting "researchPlanet" as it is no longer useful

In the future, we should think about a better default research plan (for example adding the resources production techs, the propulsion as well as the military techs)